### PR TITLE
Fix Color Normalized Issue

### DIFF
--- a/utils/transforms.py
+++ b/utils/transforms.py
@@ -11,8 +11,8 @@ from .imutils import *
 def color_normalize(x, mean):
     if x.size(0) == 1:
         x = x.repeat(3, 1, 1)
-    mean /= 255
-    for t, m in zip(x, mean):
+    normalized_mean = mean / 255
+    for t, m in zip(x, normalized_mean):
         t.sub_(m)
     return x
 


### PR DESCRIPTION
I've found the `self.pixel_means` is changed in every iteration when calling `__getitem__` due to modify of `mean` variable in `color_normalize` function

See detailed log below:
> checking pixel means __getitem__: [122.7717 115.9465 102.9801]
> checking pixel means __getitem__: [0.48145765 0.45469216 0.40384353]
> checking pixel means __getitem__: [0.00188807 0.00178311 0.0015837 ]
> checking pixel means __getitem__: [7.40419296e-06 6.99257450e-06 6.21058869e-06]
> checking pixel means __getitem__: [2.90360508e-08 2.74218608e-08 2.43552498e-08]
